### PR TITLE
Add French code of conduct, Attending/Information page

### DIFF
--- a/driconnect/config.yaml
+++ b/driconnect/config.yaml
@@ -57,6 +57,6 @@ languages:
         url: "/fr/lieu/"
         weight: 5
       - name: "Code de conduite"
-        url: "/codedeconduite"
+        url: "/fr/codedeconduite"
         weight: 6
     weight: 20

--- a/driconnect/config.yaml
+++ b/driconnect/config.yaml
@@ -24,8 +24,8 @@ languages:
       - name: "Program"
         url: "/program/"
         weight: 2
-      - name: "Registration"
-        url: "/registration/"
+      - name: "Attending"
+        url: "/attending/"
         weight: 3
       - name: "Accommodations"
         url: "/accommodations/"
@@ -47,8 +47,8 @@ languages:
       - name: "Programme"
         url: "/fr/programme/"
         weight: 2
-      - name: "Inscription"
-        url: "/fr/inscription/"
+      - name: "Information"
+        url: "/fr/information/"
         weight: 3
       - name: "Hébergement"
         url: "/fr/hebergement/"
@@ -57,6 +57,6 @@ languages:
         url: "/fr/lieu/"
         weight: 5
       - name: "Code de conduite"
-        url: "/codeofconduct"
+        url: "/codedeconduite"
         weight: 6
     weight: 20

--- a/driconnect/content/accomodation.en.md
+++ b/driconnect/content/accomodation.en.md
@@ -4,11 +4,11 @@ title: "Accommodations"
 lang_code: "en"
 translationKey: "accommodation"
 ---
-We have reserved blocks at two hotels, both a short walking distance to the Halifax Convention Centre. Please use the links below for a preferred rate.  
+We have reserved blocks at two hotels, both a short walking distance to the Halifax Convention Centre. Please use the links below for a preferred rate.
 
 **Cambridge Suites Hotel**
 
-This hotel is in the heart of Halifax, next to the famed Citadel Hill and the vibrant and historical downtown. The nightly rate is 229$. 
+This hotel is in the heart of Halifax, next to the famed Citadel Hill and the vibrant and historical downtown. The nightly rate is $229.
 
 Location:  
 1583 Brunswick St. Halifax, NS B3J 3P5  
@@ -18,20 +18,21 @@ Location:
 
 **Prince George Hotel**
 
-Less than two minutes from the Halifax Convention Centre, The Prince George is a boutique-style hotel with great charm. The nightly rate is 249$.
+Less than two minutes from the Halifax Convention Centre, The Prince George is a boutique-style hotel with great charm. The nightly rate is $249.
 
 Location:  
 1725 Market St. Halifax, NS B3J 3N9  
 1.800.565.1567  
 
-[Click here to book your stay](https://reservations.travelclick.com/13608?groupID=4214004). 
+[Click here to book your stay](https://reservations.travelclick.com/13608?groupID=4214004).
 
 Should the blocks above sell out, please find additional accommodation recommendations close to the Halifax Convention Centre:
+
 * [Sutton Place Hotel Halifax](https://www.suttonplace.com/halifax?utm_source=google&utm_medium=maps&utm_campaign=halifax)  
   New hotel in the Nova Centre, the same building as the Halifax Convention Centre  
 * [The Lord Nelson](http://www.lordnelsonhotel.com/)  
-  Though the Lord Nelson is a further walk from the Convention Centre, it is in a wonderful location next to the Halifax Public Gardens and Citadel Hill   
+  Though the Lord Nelson is a further walk from the Convention Centre, it is in a wonderful location next to the Halifax Public Gardens and Citadel Hill
 * [Barrington Hotel](https://www.thebarringtonhotel.ca/)  
   In a very central location close to the Convention Centre  
 * [Halifax Marriott Harbourfront Hotel](https://www.marriott.com/en-us/hotels/yhzmc-halifax-marriott-harbourfront-hotel/overview/?scid=f2ae0541-1279-4f24-b197-a979c79310b0)  
-  Located on the Halifax waterfront and beside the historic Lower Deck pub   
+  Located on the Halifax waterfront and beside the historic Lower Deck pub

--- a/driconnect/content/attending.en.md
+++ b/driconnect/content/attending.en.md
@@ -73,5 +73,5 @@ easy identification.
 
 Coherent Solutions are our Event Planning team. Should you need any assistance throughout the conference, do not
 hesitate to reach out to Julie Begbie or Jacqui Haines who can be found at the Registration Table in the Convention Hall
-foyer or at the Event Table at the back of the Plenary / Main Room. <julie@coherent-solutions.ca> or
+foyer or at the Event Table at the back of the Plenary/Main Room. <julie@coherent-solutions.ca> or
 <jacqui@coherent-solutions.ca>.

--- a/driconnect/content/attending.en.md
+++ b/driconnect/content/attending.en.md
@@ -1,0 +1,77 @@
+---
+slug: "attending"
+title: "Know Before You Go"
+lang_code: "en"
+translationKey: "attending"
+---
+
+DRI Connect Conference | May 27-28, 2024  
+Halifax Convention Centre  
+Halifax, NS  
+
+We look forward to welcoming you to the 2024 DRI Connect conference, whether you are joining us in-person or online!
+
+## Program
+
+We are excited to feature an exceptional lineup of presenters covering a wide range of topics. You can find the
+up-to-date [program details](/program). **Please note all times are in Atlantic time.**
+
+You might have noticed we are offering 3 parallel streams at different points throughout Day 1 and Day 2.
+
+Stream 1       Plenary/Main Room (Attendees do not need to move around)  
+Stream 2       Room 102 on the Convention Hall Level  
+Stream 3       Room 103 on the Convention Hall Level  
+
+We encourage you to pre-select the sessions you wish to attend and move quickly to the designated breakout room or Zoom
+link to ensure programming proceeds smoothly.
+
+## Zoom and Slack Details
+
+We will be using Slack during the conference.  If you already have access to the Alliance Slack workspace, simply join
+the [#driconnect](https://driconnect.slack.com/archives/CDNBKALPN) channel. (And don't forget the question channels
+too.)
+
+If you are not in the workspace, please sign-up for a free account here:  
+<https://join.slack.com/t/driconnect/shared_invite/zt-2hj67weep-TaShGTBwd~BEHVqjcaSe~Q>
+
+Each physical room will have a corresponding Zoom link and Slack question channel:
+
+- **C4 - main room for plenary talks and Stream 1 of the parallel sessions**
+
+  <https://encoreglobal.zoom.us/j/93324459328?pwd=RXlkVWhQRmhwY0tnT0tKSVJPeHlpUT09>  
+  Meeting ID: 933 2445 9328  
+  Passcode: 502099
+
+  Slack channel: [#C4questions](https://driconnect.slack.com/archives/C073BSAHXJ9)
+
+- **102 - for Stream 2 of the parallel sessions**
+
+  <https://encoreglobal.zoom.us/j/92882608925?pwd=M1l3aitjMm5JaHB4YWxiRDRFOG9BZz09>  
+  Meeting ID: 928 8260 8925  
+  Passcode: 433316
+
+  Slack channel: [#102questions](https://driconnect.slack.com/archives/C073TEDB29X)
+
+- **103 - for Stream 3 of the parallel sessions**
+
+  <https://encoreglobal.zoom.us/j/92660786909?pwd=blRlRzcxK3ErV0lKNUY2Rkpxc0dMdz09>  
+  Meeting ID: 926 6078 6909  
+  Passcode: 559860
+
+  Slack channel: [#103questions](https://driconnect.slack.com/archives/C0743JC6K32)
+
+## Meals
+
+DRI Connect will provide attendees with meals on both days of the conference. Breakfast will be served each day from
+8:00 AM to 9:00 AM and lunch from 12:30PM- 1:30PM in Convention Hall C5.
+
+Attendees who have specified dietary requirements will be accommodated and asked to make themselves known to the Banquet
+Staff to ensure specially prepared meals are delivered to them. Note that all foods will be appropriately labeled for
+easy identification.
+
+## On Site Support
+
+Coherent Solutions are our Event Planning team. Should you need any assistance throughout the conference, do not
+hesitate to reach out to Julie Begbie or Jacqui Haines who can be found at the Registration Table in the Convention Hall
+foyer or at the Event Table at the back of the Plenary / Main Room. <julie@coherent-solutions.ca> or
+<jacqui@coherent-solutions.ca>.

--- a/driconnect/content/codedeconduite.fr.md
+++ b/driconnect/content/codedeconduite.fr.md
@@ -1,0 +1,74 @@
+---
+slug: "codedeconduite"
+title: "Code de conduite"
+lang_code: "fr"
+translationKey: "codeofconduct"
+---
+
+_Adapté du Code de conduite de code4lib : <http://bit.ly/coc4lib>_
+
+Les événements constituent une merveilleuse occasion de nouer des contacts, d’apprendre les un(e)s des autres et
+d’échanger des idées. En suivant les présentes lignes directrices, nous pouvons tous contribuer à créer un environnement
+positif et respectueux qui soit propice à l’apprentissage et à la communication efficaces au profit de tous. Nous vous
+remercions de votre coopération et vous souhaitons de bien profiter de la Rencontre sur l’IRN !
+
+- Soyez respectueux(se) : Le langage discriminatoire n’est pas approprié, quel qu’en soit le lieu ou la plateforme.
+  L’Alliance ne tolère aucune forme de harcèlement. On entend par harcèlement tout comportement menaçant envers une
+  autre personne ou un groupe ou qui favorise un environnement dangereux.
+
+- Faites preuve d’ouverture d’esprit : Essayez de garder un esprit ouvert et d’être réceptif(ve) aux nouvelles idées et
+  perspectives. Dans la mesure du possible, donnez aux gens le bénéfice du doute ! Nous sommes tous ici pour apprendre,
+  et cet événement constitue une excellente occasion pour vous permettre d’approfondir votre compréhension de différents
+  sujets.
+
+## Protégeons la santé de tout le monde
+
+Vous pouvez assurer le confort des personnes qui vous entourent :
+
+- Laver régulièrement les mains et/ou utiliser du désinfectant pour les mains 🧼 🧴
+
+- Porter des chaussures adéquates en permanence 👟 👞 👠
+
+- Se couvrir la bouche et le nez lorsqu’on tousse ou éternue 🙊 🤧
+
+- Respecter le choix des personnes de porter un masque 😷 (des masques seront offerts au bureau d’inscription pour ceux
+  et celles qui souhaitent en porter un).
+
+## Partageons un espace commun sans parfum
+
+Certaines personnes sont sensibles à divers produits chimiques ou parfumés. Nous demandons à tout le monde de nous aider
+dans nos efforts visant à répondre aux inquiétudes liées à la santé de ces personnes. Des produits parfumés tels que la
+laque, le parfum, l’eau de Cologne, l’après-rasage et les déodorants très parfumés peuvent provoquer des réactions
+telles qu’une détresse respiratoire et des maux de tête chez les personnes qui en sont sensibles. Les participant(e)s en
+personne à la Rencontre sur l’IRN sont priés d’éviter d’utiliser des produits chimiques ou parfumés dans les espaces
+communs.
+
+## Directives sur les photos
+
+Veuillez demander la permission des participant(e)s avant de les prendre en photo ou de les filmer, et avant d’en
+publier les images sur les médias sociaux.
+
+## Résolution de conflits
+
+Si vous êtes témoin d’un incident ou si vous rencontrez un problème lors de votre participation à la Rencontre sur
+l’IRN, et que vous vous sentez à l’aise d’en parler à l’autre participant(e) en cause, veuillez l’informer qu’il ou elle
+vous a affecté négativement. Son comportement peut ne pas être intentionnel et la mésentente peut être résolue juste en
+vous parlant.
+
+Nous comprenons qu’il existe de nombreuses raisons pour lesquelles une ou un participant(e) peut ne pas se sentir à
+l’aise d’affronter directement le problème. Dans ce cas, il se peut que vous ayez besoin de quelqu’un pour vous venir en
+aide. Si vous assistez à la conférence en personne, vous pouvez vous faire aider par une ou un bénévole de soutien
+communautaire. Ces personnes seront présentées et repérables lors de la conférence et pourront également être contactées
+par courriel. Si vous y participez en ligne, vous pouvez envoyer un message privé à une modératrice ou à un modérateur.
+Les modératrices et modérateurs ne seraient peut-être pas des bénévoles de soutien communautaire, certes, mais ils
+sauraient comment vous orienter vers ces derniers.
+
+Toutes les conversations resteront privées et confidentielles.
+
+## Bénévoles de soutien communautaire
+
+Alex Thistlewood <alex.thistlewood@ucalgary.ca>
+
+Ines Hessler <ines.hessler@ace-net.ca>
+
+Tessa Derksen <tessa.derksen2@gmail.com>

--- a/driconnect/content/codeofconduct.en.md
+++ b/driconnect/content/codeofconduct.en.md
@@ -5,7 +5,7 @@ lang_code: "en"
 translationKey: "codeofconduct"
 ---
 
-_Adapted from code4lib’s Code of Conduct: http://bit.ly/coc4lib_
+_Adapted from code4lib’s Code of Conduct: <http://bit.ly/coc4lib>_
 
 Events are a wonderful opportunity to network, learn, and exchange ideas. By following these guidelines, we can all
 contribute to creating a positive and respectful environment where everyone can learn and connect effectively. Thank you
@@ -60,8 +60,8 @@ All conversations will be kept private and confidential.
 
 ## Community Support Volunteers
 
-Alex Thistlewood alex.thistlewood@ucalgary.ca
+Alex Thistlewood <alex.thistlewood@ucalgary.ca>
 
-Ines Hessler ines.hessler@ace-net.ca
+Ines Hessler <ines.hessler@ace-net.ca>
 
-Tessa Derksen tessa.derksen2@gmail.com
+Tessa Derksen <tessa.derksen2@gmail.com>

--- a/driconnect/content/hebergement.fr.md
+++ b/driconnect/content/hebergement.fr.md
@@ -4,34 +4,38 @@ title: "Hébergement"
 lang_code: "fr"
 translationKey: "accommodation"
 ---
+Nous avons réservé des chambres dans deux hôtels, tous deux situés à courte distance de marche du Halifax Convention
+Centre. Veuillez utiliser les liens ci-dessous pour obtenir un tarif préférentiel.
 
-Nous avons réservé des chambres dans deux hôtels, tous deux situés à courte distance de marche du Halifax Convention Centre. Veuillez utiliser les liens ci-dessous pour obtenir un tarif préférentiel. 
+**Cambridge Suites Hotel**
 
-**Cambridge Suites Hotel**  
-Cet hôtel se trouve au cœur d'Halifax, à proximité de la célèbre colline de la Citadelle et du centre-ville historique et bourdonnant d'activités . Le tarif par nuitée est de 229$. 
+Cet hôtel se trouve au cœur d'Halifax, à proximité de la célèbre colline de la Citadelle et du centre-ville historique
+et bourdonnant d'activités . Le tarif par nuitée est de 229$.
 
 Adresse:  
 1583 Brunswick St. Halifax, N.-É. B3J 3P5  
 1.800.565.1263
 
-[Cliquez ici pour effectuer la réservation](https://reservations.travelclick.com/13605?groupID=4213995). 
+[Cliquez ici pour effectuer la réservation](https://reservations.travelclick.com/13605?groupID=4213995).
 
 **Prince George Hotel**
 
-Situé à moins de deux minutes du Halifax Convention Centre, le Prince George est un hôtel charmant. Le tarif par nuitée est de 249$. 
+Situé à moins de deux minutes du Halifax Convention Centre, le Prince George est un hôtel charmant. Le tarif par nuitée
+est de 249$.
 
 Adresse:  
 1725 Market St. Halifax, N.-É. B3J 3N9  
 1.800.565.1567
 
-[Cliquez ici pour effectuer la réservation](https://reservations.travelclick.com/13608?groupID=4214004). 
+[Cliquez ici pour effectuer la réservation](https://reservations.travelclick.com/13608?groupID=4214004).
 
-Si les blocs ci-dessus sont épuisés, veuillez trouver ci-après d'autres recommandations d'hébergement à proximité du Halifax Convention Centre: 
+Si les blocs ci-dessus sont épuisés, veuillez trouver ci-après d'autres recommandations d'hébergement à proximité du Halifax Convention Centre:
+
 * [Sutton Place Hotel Halifax](https://www.suttonplace.com/halifax?utm_source=google&utm_medium=maps&utm_campaign=halifax)  
-  Nouvel hôtel dans le Nova Centre, dans le même bâtiment que le Halifax Convention Centre.  
+  Nouvel hôtel dans le Nova Centre, dans le même bâtiment que le Halifax Convention Centre.
 * [The Lord Nelson](http://www.lordnelsonhotel.com/)  
-  Bien que le Lord Nelson soit plus éloigné, il bénéficie d'un emplacement magnifique à proximité des Halifax Public Gardens et de la colline de la Citadelle.  
+  Bien que le Lord Nelson soit plus éloigné, il bénéficie d'un emplacement magnifique à proximité des Halifax Public Gardens et de la colline de la Citadelle.
 * [Barrington Hotel](https://www.thebarringtonhotel.ca/)  
-  Lieu central, à proximité du Halifax Convention Centre  
+  Lieu central, à proximité du Halifax Convention Centre
 * [Halifax Marriott Harbourfront Hotel](https://www.marriott.com/en-us/hotels/yhzmc-halifax-marriott-harbourfront-hotel/overview/?scid=f2ae0541-1279-4f24-b197-a979c79310b0)  
-  Situé sur le front de mer d'Halifax et à côté du pub historique Lower Deck  
+  Situé sur le front de mer d'Halifax et à côté du pub historique Lower Deck

--- a/driconnect/content/information.fr.md
+++ b/driconnect/content/information.fr.md
@@ -1,0 +1,80 @@
+---
+slug: "information"
+title: "Renseignements utiles avant la conférence"
+lang_code: "fr"
+translationKey: "attending"
+---
+
+Conférence de la Rencontre sur l’IRN | 27—28 mai 2024  
+Halifax Convention Centre (Nouvelle-Écosse)
+
+Nous avons hâte de vous accueillir à la Conférence de la Rencontre sur l’IRN, que vous nous joigniez en personne ou en ligne !
+
+## Programme
+
+Nous avons une liste exceptionnelle de présentatrices et présentateurs dont les interventions couvriront un large
+éventail de sujets. Cliquez sur [ce lien pour consulter le programme](/fr/programme).
+**Veuillez noter que l’horaire est exprimé en heure de l’Atlantique.**
+
+Nous proposons 3 volets à différents moments de la première et de la deuxième journées.
+
+Volet 1       Salle des plénières/salle principale (les participant(e)s n’auront pas à se déplacer)  
+Volet 2       Salle 102 au Convention Hall Level  
+Volet 3       Salle 103 au Convention Hall Level  
+
+Nous vous encourageons à présélectionner les séances auxquelles vous souhaitez participer, notamment les salles qui y
+sont consacrées, et à vous y rendre ou à vous connecter rapidement sur Zoom, le moment venu, afin de favoriser un
+déroulement sans heurts du programme.
+
+## Détails Zoom et Slack
+
+Nous utiliserons Slack pendant la conférence.  Si vous avez déjà accès à l'espace de travail Slack de l'Alliance, il
+vous suffit de rejoindre le canal [#driconnect](https://driconnect.slack.com/archives/CDNBKALPN) (N'oubliez pas non plus
+les canaux de questions).
+
+Si vous n’avez pas accès à l’espace de travail de l’Alliance, vous pouvez ouvrir un compte gratuit au lien ci-après :
+<https://join.slack.com/t/driconnect/shared_invite/zt-2hj67weep-TaShGTBwd~BEHVqjcaSe~Q>
+
+Chaque salle aura un lien Zoom et un canal de questions Slack correspondants :
+
+- **C4 – salle principale pour les conférences plénières et le volet 1 des séances parallèles**
+
+  <https://encoreglobal.zoom.us/j/93324459328?pwd=RXlkVWhQRmhwY0tnT0tKSVJPeHlpUT09>  
+  ID de la réunion : 933 2445 9328  
+  Code d’accès : 502099
+
+  Canal Slack : [#C4questions](https://driconnect.slack.com/archives/C073BSAHXJ9)
+
+- **102 – pour le Volet 2 des séances parallèles**
+
+  <https://encoreglobal.zoom.us/j/92882608925?pwd=M1l3aitjMm5JaHB4YWxiRDRFOG9BZz09>  
+  ID de la réunion : 928 8260 8925  
+  Code d’accès : 433 316
+
+  Canal Slack : [#102questions](https://driconnect.slack.com/archives/C073TEDB29X)
+
+- **103 – pour le volet 3 des séances parallèles**
+
+  <https://encoreglobal.zoom.us/j/92660786909?pwd=blRlRzcxK3ErV0lKNUY2Rkpxc0dMdz09>  
+  ID de la réunion : 926 6078 6909  
+  Code d’accès : 559860
+
+  Canal Slack : [#103questions](https://driconnect.slack.com/archives/C0743JC6K32)
+
+## Repas
+
+La Rencontre sur l’IRN fournira des repas aux participant(e)s pendant les deux journées de la conférence. Le
+petit-déjeuner sera servi chaque jour de 8 h à 9 h et le déjeuner de 12 h 30 à 13 h 30 dans la salle des repas du
+Convention Hall C5.
+
+Les besoins nutritionnels particuliers seront pris en considération. Nous demandons aux participant(e)s de faire
+connaître leurs besoins alimentaires particuliers au personnel du banquet afin que des repas tenant compte de ces
+besoins leur soient offerts. Veuillez noter que tous les aliments seront convenablement étiquetés afin d’en permettre
+l’identification.
+
+## Soutien sur place
+
+Coherent Solutions est notre équipe chargée de l’organisation de l’événement. Si vous avez besoin d’aide durant la
+conférence, n’hésitez pas à contacter Julie Begbie ou Jacqui Haines qui seront à la table d’inscription dans le foyer de
+la salle des congrès (Convention Hall Foyer) ou à la table de l’événement derrière la salle des plénières/salle
+principale. <julie@coherent-solutions.ca> ou <jacqui@coherent-solutions.ca>.

--- a/driconnect/content/inscription.fr.md
+++ b/driconnect/content/inscription.fr.md
@@ -7,8 +7,8 @@ translationKey: "registration"
 
 Les inscriptions pour participer en personne sont complètes. Toutefois, la participation virtuelle reste ouverte.
 Veuillez cliquez sur le lien suivant pour vous inscrire:
-https://events.myconferencesuite.com/DRIConnect/reg/landing
+<https://events.myconferencesuite.com/DRIConnect/reg/landing>
 
-# Coût 
+## Coût
 
-La participation à cet événement est gratuite. Cependant, tout frais lié aux vols, à l'hébergement, et aux repas, en dehors de ceux offerts dans le cadre de l’événement, seront à la charge de chaque participant.  
+La participation à cet événement est gratuite. Cependant, tout frais lié aux vols, à l'hébergement, et aux repas, en dehors de ceux offerts dans le cadre de l’événement, seront à la charge de chaque participant.

--- a/driconnect/content/lieu.fr.md
+++ b/driconnect/content/lieu.fr.md
@@ -24,11 +24,11 @@ Pour ceux et celles qui se rendront en voiture à la conférence, le stationneme
 
 Une réunion informelle sera organisée le dimanche 26 mai en soirée pour les participantes et participants habitant dans
 la région ou qui arrivent en ville ce jour-là. Planifiez votre voyage en conséquence et venez rencontrer vos collègues
-et vos connaissances, anciens et nouveaux. Le lieu sera annoncé ultérieurement.
+et vos connaissances, anciens et nouveaux.
 
 ## Que faire à Halifax
 
-En marge de la rencontre sur l’IRN, il y aura beaucoup de choses à voir et à faire à Halifax !  
+En marge de la rencontre sur l’IRN, il y aura beaucoup de choses à voir et à faire à Halifax !
 
 En voici quelques suggestions :
 

--- a/driconnect/content/location.en.md
+++ b/driconnect/content/location.en.md
@@ -22,11 +22,11 @@ For those driving / commuting to DRI Connect, parking is available in the Nova C
 ## Gathering with ACENET
 
 There will be an informal gathering the evening of Sunday, May 26, for locals and those just arriving in town. Make your
-travel plans accordingly and drop by to meet up with colleagues and friends, both old and new. Location to be announced.
+travel plans accordingly and drop by to meet up with colleagues and friends, both old and new.
 
 ## What to do in Halifax
 
-When not attending DRI Connect, there is plenty to see and do in Halifax!  
+When not attending DRI Connect, there is plenty to see and do in Halifax!
 
 Some suggestions include:
 

--- a/driconnect/content/program.en.md
+++ b/driconnect/content/program.en.md
@@ -22,7 +22,7 @@ that leverages the full potential of digital research infrastructure (DRI) in Ca
 
 #### DRI Connect Dinner and ACENET Celebration
 
-We look forward to hosting DRI Connect guests for a celebratory dinner on May 27, 2024! More information to come.
+We look forward to hosting DRI Connect guests for a celebratory dinner on May 27, 2024!
 
 ### Program
 

--- a/driconnect/content/program.en.md
+++ b/driconnect/content/program.en.md
@@ -353,13 +353,13 @@ We look forward to hosting DRI Connect guests for a celebratory dinner on May 27
       <div class="col-2">C4</div>
       <div class="col">
         <details>
-          <summary class="h6">The National ARC Training Coordination Council</summary>
+          <summary class="h6">The National Training Coordination Council</summary>
           <p>
-            Ramses Van zon, Chair, National ARC Training Coordination Council
+            Ramses Van zon, Chair, National Training Coordination Council
           </p>
           <p>
-            Learn all about the newly formed National ARC Training Coordination Council, including its purpose, goals
-            and where we stand nationally in ARC training.
+            Learn all about the newly formed National Training Coordination Council, including its purpose, goals
+            and where we stand nationally in training.
           </p>
         </details>
       </div>

--- a/driconnect/content/program.fr.md
+++ b/driconnect/content/program.fr.md
@@ -23,7 +23,7 @@ numérique (IRN) au Canada.
 
 #### Soirée de la rencontre sur l'IRN et célébration d'ACENET
 
-Un souper de célébration sera offert aux participantes et participants de la rencontre sur l'IRN le 27 mai 2024. Plus d'informations à venir.
+Un souper de célébration sera offert aux participantes et participants de la rencontre sur l'IRN le 27 mai 2024.
 
 ### Programme
 

--- a/driconnect/content/program.fr.md
+++ b/driconnect/content/program.fr.md
@@ -361,12 +361,12 @@ Un souper de célébration sera offert aux participantes et participants de la r
       <div class="col-2">C4</div>
       <div class="col">
         <details>
-          <summary class="h6">Conseil national de coordination de la formation en CIP </summary>
+          <summary class="h6">Conseil national de coordination de la formation</summary>
           <p>
-            Ramses Van zon, président du Conseil national de coordination de la formation en CIP
+            Ramses Van zon, président du Conseil national de coordination de la formation
           </p>
           <p>
-            Venez découvrir cette entité nouvellement créée ainsi que sa mission, ses buts et notre positionnement, à l'échelle nationale, en matière de formation en CIP.
+            Venez découvrir cette entité nouvellement créée ainsi que sa mission, ses buts et notre positionnement, à l'échelle nationale, en matière de formation.
           </p>
         </details>
       </div>

--- a/driconnect/content/registration.en.md
+++ b/driconnect/content/registration.en.md
@@ -7,9 +7,9 @@ translationKey: "registration"
 
 In Person Registration has been filled up. However, virtual attendance remains open.
 Please register at the following link:
-https://events.myconferencesuite.com/DRIConnect/reg/landing
+<https://events.myconferencesuite.com/DRIConnect/reg/landing>
 
-# Cost
+## Cost
 
 There is no cost to attend this event.
 However, flight, accommodations and any meals outside of the event


### PR DESCRIPTION
This also removes the Registration pages from the navigation, but doesn't delete them, since they will be useful for next year.